### PR TITLE
feat(votes): show votes from all dao versions

### DIFF
--- a/src/components/complex/Proposal/index.jsx
+++ b/src/components/complex/Proposal/index.jsx
@@ -1,5 +1,7 @@
 import React, { Fragment, useCallback, useMemo, useState, useEffect } from 'react'
 import { Row, Col } from 'react-bootstrap'
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+import Tooltip from 'react-bootstrap/Tooltip'
 import styled from 'styled-components'
 import { usePrepareContractWrite, useContractWrite, useChainId, useAccount } from 'wagmi'
 import { toast } from 'react-toastify'
@@ -17,6 +19,7 @@ import Action from '../Action'
 import Line from '../../base/Line'
 import Spinner from '../../base/Spinner'
 import Badge from '../../base/Badge'
+import { formatAssetAmount } from '../../../utils/amount'
 
 const ProposalContainer = styled.div`
   display: flex;
@@ -104,6 +107,10 @@ const QuorumText = styled(Text)`
   color: ${({ theme, quorumreached }) => (quorumreached ? theme.yellow : theme.red)};
 `
 
+const QuorumContainer = styled.div`
+  margin-left: 7px;
+`
+
 const StyledIcon = styled(Icon)`
   margin-right: 5px;
 `
@@ -157,7 +164,10 @@ const Proposal = ({
   formattedPercentageNay,
   formattedPercentageYea,
   formattedVote,
+  votingPnt,
   formattedVotingPnt,
+  votingPntDouble,
+  formattedVotingPntDouble,
   id,
   idText,
   open,
@@ -229,6 +239,14 @@ const Proposal = ({
     }
   }, [noData, activeChainId])
 
+  const renderTooltip = (props) => (
+    <Tooltip id="button-tooltip" {...props}>
+      <Text>
+        {formattedVotingPntDouble ? `${formattedVotingPnt} on DAO-v2 and ${formattedVotingPntDouble} on DAO-v1` : null}
+      </Text>
+    </Tooltip>
+  )
+
   return (
     <ProposalContainer disabled={disabled}>
       <StatusLine type={type} />
@@ -260,7 +278,7 @@ const Proposal = ({
         </Row>
         <Row className="mt-2">
           <Col>
-            <QuorumText quorumreached={quorumReached.toString()}>
+            <QuorumText quorumreached={quorumReached}>
               {quorumReached ? 'The quorum has been reached' : "The quorum hasn't been reached"}
             </QuorumText>
           </Col>
@@ -268,9 +286,17 @@ const Proposal = ({
         <Row className="mt-2">
           <Col className="d-flex align-items-center">
             <StyledIcon icon="people" />
-            <Text>
-              Voted by <Text variant="text2">{formattedVotingPnt}</Text>
-            </Text>
+            {votingPntDouble ? (
+              <OverlayTrigger placement="right" delay={{ show: 250, hide: 400 }} overlay={renderTooltip}>
+                <Text>
+                  Voted by <Text variant="text2"> {formatAssetAmount(votingPnt.plus(votingPntDouble), 'PNT')}</Text>
+                </Text>
+              </OverlayTrigger>
+            ) : (
+              <Text>
+                Voted by <Text variant="text2">{formattedVotingPnt}</Text>
+              </Text>
+            )}
           </Col>
         </Row>
         <Row className="mt-2">

--- a/src/utils/proposals.js
+++ b/src/utils/proposals.js
@@ -103,7 +103,7 @@ const prepareOldProposal = (
     id: _proposal.id + _idStart,
     minAcceptQuorum: minAcceptQuorum.toFixed(),
     multihash: url.slice(url.length - 46, url.length),
-    no: no.toFixed(),
+    no: no,
     open,
     passed,
     quorum: quorum.toFixed(),
@@ -113,8 +113,8 @@ const prepareOldProposal = (
     startBlock: startBlock.toNumber(),
     url,
     votingPnt,
-    votingPower: votingPower.toFixed(),
-    yes: yes.toFixed()
+    votingPower: votingPower,
+    yes: yes
   }
 }
 
@@ -124,7 +124,6 @@ const prepareNewProposal = (_proposal, _voteData, _voteActions, _chainId, _idSta
   const votingPower = BigNumber(_voteData.votingPower.toString()).dividedBy(10 ** 18)
   const no = BigNumber(_voteData.nay.toString()).dividedBy(10 ** 18)
   const yes = BigNumber(_voteData.yea.toString()).dividedBy(10 ** 18)
-
   const votingPnt = yes.plus(no)
   const percentageYea = yes.dividedBy(votingPnt).multipliedBy(100)
   const percentageNay = no.dividedBy(votingPnt).multipliedBy(100)
@@ -165,7 +164,7 @@ const prepareNewProposal = (_proposal, _voteData, _voteActions, _chainId, _idSta
     id: _proposal.id + _idStart,
     minAcceptQuorum: minAcceptQuorum.toFixed(),
     multihash: url.slice(url.length - 46, url.length),
-    no: no.toFixed(),
+    no: no,
     open,
     passed,
     quorum: quorum.toFixed(),
@@ -175,8 +174,8 @@ const prepareNewProposal = (_proposal, _voteData, _voteActions, _chainId, _idSta
     startDate: startDate.toNumber(),
     url,
     votingPnt,
-    votingPower: votingPower.toFixed(),
-    yes: yes.toFixed()
+    votingPower: votingPower,
+    yes: yes
   }
 }
 


### PR DESCRIPTION
Current DAO proposals can be voted both on DAO v1 and DAO v2 and the actual outcome is given by the sum of the votes on both the DAOs. Currently in DAO v2 is shown only the data of votes happened on DAOv2 itself and therefore it is not straightforward to have a complete picture of the proposal status. 
With this PR the cumulative data is used instead of the one from just the DAOv2. In particular:
- the status is `OPEN` until the aggregate of the DAOs is `PASSED` or `NOT PASSED`
- the percentage is calculated on aggregated locked PNT and votes
- the quorum is based on the aggregated YES votes and locked PNT
- the number of PNT that have voted is the sum of both DAOS

Example:
Old: 
![image](https://github.com/pnetwork-association/dao-v2-ui/assets/26067523/9af30873-fee8-4e9f-9378-810ebbb919bb)
New:
![image](https://github.com/pnetwork-association/dao-v2-ui/assets/26067523/ad617039-d0fc-4c52-a2d2-bff819443f9d)
